### PR TITLE
Allow to retrieve DIR in parameters

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -98,6 +98,8 @@ class TerminalCommand():
             if not dir:
                 raise NotFoundError('The file open in the selected view has ' +
                     'not yet been saved')
+            for k, v in enumerate(parameters):
+                parameters[k] = v.replace('%SB2_DIR%', dir)
             args = [TerminalSelector.get()]
             args.extend(parameters)
             subprocess.Popen(args, cwd=dir)


### PR DESCRIPTION
 %SB2_DIR% replaced by DIR. Useful to execute directly a command with this dir.

Example : Key bindings to use Livereload on actual project and have concerned DIR in terminal title.

[
    {
        "keys": ["ctrl+shift+l"],
        "command": "open_terminal_project_folder",
        "args": {
            "parameters": ["--title=SB2 : %SB2_DIR%", "-x", "sh", "-c", "livereload"]
        }
    }
]
