### PR TITLE
Fixed local variable getting referenced before assignment

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -17,6 +17,7 @@ class TerminalSelector():
 
     @staticmethod
     def get():
+        global default
         settings = sublime.load_settings('Terminal.sublime-settings')
         package_dir = os.path.join(sublime.packages_path(), __name__)
 


### PR DESCRIPTION
Defined a global variable 'default' to fix an issue where the following error pops up after installing the package in Sublime Text and trying to fire up a terminal - Terminal: local variable 'default' referenced before assignment
