### PR TITLE
Encoding bug

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -105,7 +105,7 @@ class TerminalCommand():
                 parameters[k] = v.replace('%CWD%', dir)
             args = [TerminalSelector.get()]
             args.extend(parameters)
-            encoding = locale.getpreferredencoding(do_setlocale=True)
+            encoding = locale.getfilesystemencoding()
             subprocess.Popen(args, cwd=dir.encode(encoding))
 
         except (OSError) as (exception):


### PR DESCRIPTION
For file paths, using the system file encoding is more reliable that the preferred encoding, so I made a one line change to fix that.