### PR TITLE
Support platform-specific settings

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -13,7 +13,7 @@ class NotFoundError(Exception):
     pass
 
 def get_platform_setting(settings, key):
-    value = settings.get('%s_%s' % (key, sys.platform))
+    value = settings.get('%s_%s' % (key, sublime.platform()))
     if not value:
         value = settings.get(key)
     return value

--- a/Terminal.py
+++ b/Terminal.py
@@ -12,6 +12,11 @@ if os.name == 'nt':
 class NotFoundError(Exception):
     pass
 
+def get_platform_setting(settings, key):
+    value = settings.get('%s_%s' % (key, sys.platform))
+    if not value:
+        value = settings.get(key)
+    return value
 
 class TerminalSelector():
     default = None
@@ -21,7 +26,7 @@ class TerminalSelector():
         settings = sublime.load_settings('Terminal.sublime-settings')
         package_dir = os.path.join(sublime.packages_path(), __name__)
 
-        terminal = settings.get('terminal')
+        terminal = get_platform_setting(settings, 'terminal')
         if terminal:
             dir, executable = os.path.split(terminal)
             if not dir:
@@ -124,7 +129,7 @@ class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
 
         if parameters == None:
             settings = sublime.load_settings('Terminal.sublime-settings')
-            parameters = settings.get('parameters')
+            parameters = get_platform_setting(settings, 'parameters')
 
         if not parameters:
             parameters = []

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -10,14 +10,13 @@
 	"parameters": []
 
     // You can also supply platform-specific terminal commands and parameters
-    // by suffixing the setting name with the relevant value of sys.platform,
-    // like so:
-    // "terminal_win32": "",
-    // "parameters_win32": "",
-    // "terminal_linux2": "",
-    // "parameters_linux2": "",
-    // "terminal_darwin": "",
-    // "parameters_darwin": ""
+    // by suffixing the setting name with the relevant platform name, like so:
+    // "terminal_windows": "",
+    // "parameters_windows": "",
+    // "terminal_linux": "",
+    // "parameters_linux": "",
+    // "terminal_osx": "",
+    // "parameters_osx": ""
     // for Windows, Linux and OS X, respectively. If a platform-specific setting
     // is found, it takes precedence over the platform-independent setting.
 }

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -8,4 +8,16 @@
 	// dict when calling the "open_terminal" or "open_terminal_project_folder"
 	// commands
 	"parameters": []
+
+    // You can also supply platform-specific terminal commands and parameters
+    // by suffixing the setting name with the relevant value of sys.platform,
+    // like so:
+    // "terminal_win32": "",
+    // "parameters_win32": "",
+    // "terminal_linux2": "",
+    // "parameters_linux2": "",
+    // "terminal_darwin": "",
+    // "parameters_darwin": ""
+    // for Windows, Linux and OS X, respectively. If a platform-specific setting
+    // is found, it takes precedence over the platform-independent setting.
 }


### PR DESCRIPTION
Being able to specify different terminals depending on the platform ST2 is running on is useful for people (like me) who migrate their configuration between multiple systems. This change adds support for `terminal_<sublime.platform()>` and `parameters_<sublime.platform()>` settings to support that. The regular platform-independent still exist and are used as fallback in case no platform-specific setting is set.