### PR TITLE
terminal get error with installed windows portable version

### DIFF
--- a/PS.bat
+++ b/PS.bat
@@ -1,1 +1,1 @@
-start powershell -noexit -ExecutionPolicy RemoteSigned "%APPDATA%\Sublime` Text` 2\Packages\Terminal\PS.ps1"
+start powershell -noexit -ExecutionPolicy RemoteSigned "%~dp0\PS.ps1"


### PR DESCRIPTION
In windows portable version, PS1.bat file get error that is called %APPDATA% but that is't exist