### PR TITLE
iTerm.sh improvements

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -3,7 +3,6 @@ import sublime_plugin
 import os
 import sys
 import subprocess
-import locale
 import stat
 
 if os.name == 'nt':
@@ -106,8 +105,7 @@ class TerminalCommand():
                 parameters[k] = v.replace('%CWD%', dir)
             args = [TerminalSelector.get()]
             args.extend(parameters)
-            encoding = locale.getpreferredencoding(do_setlocale=True)
-            subprocess.Popen(args, cwd=dir.encode(encoding))
+            subprocess.Popen(args, cwd=dir)
 
         except OSError as exception:
             print(exception)

--- a/Terminal.py
+++ b/Terminal.py
@@ -4,6 +4,7 @@ import os
 import sys
 import subprocess
 import locale
+import stat
 
 if os.name == 'nt':
     import _winreg
@@ -19,7 +20,7 @@ class TerminalSelector():
     @staticmethod
     def get():
         settings = sublime.load_settings('Terminal.sublime-settings')
-        package_dir = os.path.join(sublime.packages_path(), __name__)
+        package_dir = os.path.join(sublime.packages_path(), __name__.split('.')[0])
 
         terminal = settings.get('terminal')
         if terminal:
@@ -29,7 +30,7 @@ class TerminalSelector():
                 if os.path.exists(joined_terminal):
                     terminal = joined_terminal
                     if not os.access(terminal, os.X_OK):
-                        os.chmod(terminal, 0755)
+                        os.chmod(terminal, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
             return terminal
 
         if TerminalSelector.default:
@@ -64,7 +65,7 @@ class TerminalSelector():
         elif sys.platform == 'darwin':
             default = os.path.join(package_dir, 'Terminal.sh')
             if not os.access(default, os.X_OK):
-                os.chmod(default, 0755)
+                os.chmod(default, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
         else:
             ps = 'ps -eo comm | grep -E "gnome-session|ksmserver|' + \
@@ -108,12 +109,12 @@ class TerminalCommand():
             encoding = locale.getpreferredencoding(do_setlocale=True)
             subprocess.Popen(args, cwd=dir.encode(encoding))
 
-        except (OSError) as (exception):
-            print str(exception)
+        except OSError as exception:
+            print(exception)
             sublime.error_message(__name__ + ': The terminal ' +
                 TerminalSelector.get() + ' was not found')
-        except (Exception) as (exception):
-            sublime.error_message(__name__ + ': ' + str(exception))
+        except Exception as exception:
+            sublime.error_message(__name__ + ': ' + exception)
 
 
 class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
-VERSION=$(sw_vers -productVersion)
-if (( $(expr $VERSION '<' 10.7) || $(expr $VERSION '>=' 10.8) )); then
-	RUNNING=$(ps -eo pid,comm -U $UID  | grep iTerm.app | grep -v grep | wc -l)
-else
-	RUNNING=1
-fi
+# This:
+# > tell application "System Events" to set iTermIsRunning to exists (processes where bundle identifier is "com.googlecode.iterm2")
+# does not currently work properly, since it will always report iTerm as running. Not intended, since
+# running first osascript snippet when no iTerm is actually running results in extra tab being opened.
+RUNNING=$(ps -eo pid,comm -U $UID  | grep iTerm.app | wc -l)
 
 if (( $RUNNING )); then
 	osascript<<END
 	tell application "iTerm"
-		set term to (make new terminal)
+		try
+			set term to last terminal
+		on error
+			set term to (make new terminal)
+		end try
 		tell term
 			set sess to (launch session "Default Session")
 			tell sess

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -2,16 +2,10 @@
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
 VERSION=$(sw_vers -productVersion)
-
-if (( $(expr $VERSION '<' 10.7) )); then
-	RUNNING=$(osascript<<END
-	tell application "System Events"
-	    count(processes whose name is "iTerm")
-	end tell
-END
-)
+if (( $(expr $VERSION '<' 10.7) || $(expr $VERSION '>=' 10.8) )); then
+	RUNNING=$(ps -eo pid,comm -U $UID  | grep iTerm.app | grep -v grep | wc -l)
 else
-	RUNNING=1
+    RUNNING=1
 fi
 
 if (( $RUNNING )); then

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -11,7 +11,6 @@ fi
 if (( $RUNNING )); then
 	osascript<<END
 	tell application "iTerm"
-		activate
 		set term to (make new terminal)
 		tell term
 			set sess to (launch session "Default Session")
@@ -19,16 +18,17 @@ if (( $RUNNING )); then
 				write text "$CD_CMD"
 			end tell
 		end tell
+		activate
 	end tell
 END
 else
 	osascript<<END
 	tell application "iTerm"
-		activate
 		set sess to the first session of the first terminal
 		tell sess
 			write text "$CD_CMD"
 		end tell
+		activate
 	end tell
 END
 fi

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -5,7 +5,7 @@ VERSION=$(sw_vers -productVersion)
 if (( $(expr $VERSION '<' 10.7) || $(expr $VERSION '>=' 10.8) )); then
 	RUNNING=$(ps -eo pid,comm -U $UID  | grep iTerm.app | grep -v grep | wc -l)
 else
-    RUNNING=1
+	RUNNING=1
 fi
 
 if (( $RUNNING )); then


### PR DESCRIPTION
Not sure if these commits are worth merging back, but I'd got two issues with iTerm.sh which I fixed for myself:
* iTerm.sh was launching two instances of terminal on first use (in osx 10.8, at least)
* Desktop was being switched from the current one, if there was a terminal instance on another desktop.

There is another file being changed, Terminal.py, which I adapted to run in SublimeText3 beta. It should certainly not be pulled, since it will (probably) break the plugin for ST2 users, but I don't know how to remove it from pull request, unfortunately.