### PR TITLE
Shows ""Open Terminal Here…" in tab Context Context.sublime-menu

### DIFF
--- a/Tab Context.sublime-menu
+++ b/Tab Context.sublime-menu
@@ -1,0 +1,3 @@
+[
+    { "caption": "Open Terminal Here…", "command": "open_terminal", "args": {"paths": []} }
+]


### PR DESCRIPTION
i just added a "Tab context" menu entry to open a terminal per mouse.
Useful if you want to open a terminal for a file opened in background.