### PR TITLE
Fixes Portable ST Terminal

### DIFF
--- a/PS.bat
+++ b/PS.bat
@@ -1,1 +1,1 @@
-start powershell -noexit -ExecutionPolicy RemoteSigned "%APPDATA%\Sublime` Text` 2\Packages\Terminal\PS.ps1"
+start powershell -noexit -ExecutionPolicy RemoteSigned "%sublime%\Data\Packages\Terminal\PS.ps1"

--- a/Terminal.py
+++ b/Terminal.py
@@ -58,6 +58,7 @@ class TerminalSelector():
                     _winreg.SetValueEx(key, 'ColorTable06', 0,
                         _winreg.REG_DWORD, 15789550)
                 default = os.path.join(package_dir, 'PS.bat')
+                os.putenv('sublime', os.getcwd().replace(' ', '` '))
             else :
                 default = os.environ['SYSTEMROOT'] + '\\System32\\cmd.exe'
 


### PR DESCRIPTION
By setting and getting ENV to pass the $program_dir to batch file, make it get the correct path.

Signed-off-by: mail6543210 mail6543210@yahoo.com.tw
