### PR TITLE
Fixes Portable ST Terminal(#18) and #25

### DIFF
--- a/PS.bat
+++ b/PS.bat
@@ -1,1 +1,1 @@
-start powershell -noexit -ExecutionPolicy RemoteSigned "%APPDATA%\Sublime` Text` 2\Packages\Terminal\PS.ps1"
+start powershell -noexit -ExecutionPolicy RemoteSigned "%sublime%\Data\Packages\Terminal\PS.ps1"

--- a/Terminal.py
+++ b/Terminal.py
@@ -104,9 +104,12 @@ class TerminalCommand():
                     'not yet been saved')
             for k, v in enumerate(parameters):
                 parameters[k] = v.replace('%CWD%', dir)
-            args = [TerminalSelector.get()]
-            args.extend(parameters)
+            fs_encoding=sys.getfilesystemencoding()
+            args = [TerminalSelector.get().encode(fs_encoding)]
             encoding = locale.getpreferredencoding(do_setlocale=True)
+            for i,parameters in enumerate(parameters):
+                parameters[i]=parameters[i].encode(encoding)
+            args.extend(parameters)
             subprocess.Popen(args, cwd=dir.encode(encoding))
 
         except (OSError) as (exception):

--- a/Terminal.py
+++ b/Terminal.py
@@ -58,6 +58,7 @@ class TerminalSelector():
                     _winreg.SetValueEx(key, 'ColorTable06', 0,
                         _winreg.REG_DWORD, 15789550)
                 default = os.path.join(package_dir, 'PS.bat')
+                os.putenv('sublime', os.getcwd().replace(' ', '` '))
             else :
                 default = os.environ['SYSTEMROOT'] + '\\System32\\cmd.exe'
 


### PR DESCRIPTION
When ST locates in non-ascii path, `Popen` will raise `UnicodeEncodeError` because `args`(includes `parameters`) was encoded from `unicode` to `ascii`(specified by `#-*-coding-*-`)

Manual encoding them into correct encodings.