### PR TITLE
Simplify iTerm.sh and fix for OSX Mountain Lion

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,12 @@
+License Notices
+===============
+
+`iTerm.sh`
+----------
+
+The Apple Script in `iTerm.sh` is taken from [Ben Alman](http://benalman.com)'s
+[Finder Open iTerm Here](https://gist.github.com/cowboy/905546) script:
+
+    Copyright (c) 2011 "Cowboy" Ben Alman
+    Dual licensed under the MIT and GPL licenses.
+    http://benalman.com/about/license/

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -1,40 +1,24 @@
 #!/bin/bash
 
-CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
-VERSION=$(sw_vers -productVersion)
+###
+# See Notice.md for attribution
+###
 
-if (( $(expr $VERSION '<' 10.7) )); then
-	RUNNING=$(osascript<<END
-	tell application "System Events"
-	    count(processes whose name is "iTerm")
-	end tell
-END
-)
-else
-	RUNNING=1
-fi
+CD_PATH="$(pwd)"
 
-if (( $RUNNING )); then
-	osascript<<END
-	tell application "iTerm"
-		activate
-		set term to (make new terminal)
-		tell term
-			set sess to (launch session "Default Session")
-			tell sess
-				write text "$CD_CMD"
-			end tell
-		end tell
-	end tell
+osascript<<END
+set myPath to quoted form of POSIX path of "$CD_PATH"
+
+tell application "iTerm"
+  activate
+  if the (count of terminal) is 0 then
+    set myTerm to make new terminal
+  else
+    set myTerm to the current terminal
+  end if
+  tell myTerm
+    launch session "Default Session"
+    tell the last session to write text "cd " & myPath
+  end tell
+end tell
 END
-else
-	osascript<<END
-	tell application "iTerm"
-		activate
-		set sess to the first session of the first terminal
-		tell sess
-			write text "$CD_CMD"
-		end tell
-	end tell
-END
-fi


### PR DESCRIPTION
This fixes iTerm.sh for OSX Mountain Lion.  It also greatly simplifies the iTerm.sh script