### PR TITLE
Fixed issue with saved new files

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -104,9 +104,12 @@ class TerminalCommand():
     def get_path(self, paths):
         if paths:
             return paths[0]
-        elif self.window.active_view():
-            return self.window.active_view().file_name()
-        elif self.window.folders():
+        view = self.window.active_view()
+        if view is not None:
+            file_name = self.window.active_view().file_name()
+            if file_name is not None:
+                return file_name
+        if self.window.folders():
             return self.window.folders()[0]
         else:
             sublime.error_message('Terminal: No place to open terminal to')


### PR DESCRIPTION
When a new file is created, `bool(view)` is `False`, even after it gets saved. This causes sublime_terminal to refuse to open a terminal in the directory of the newly created and saved file. This may be a ST2 only bug.