### PR TITLE
[ADD] possibility to use %FILE% and %LINE% in commands

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -113,12 +113,20 @@ class TerminalCommand():
             return False
 
     def run_terminal(self, dir_, parameters):
+        view = self.window.active_view()
+        replaces = {
+            '%CWD%': dir_,
+            '%FILE%': self.window.active_view().file_name(),
+            '%LINE%': str(view.rowcol(view.sel()[0].begin())[0] + 1)
+        }
         try:
             if not dir_:
                 raise NotFoundError('The file open in the selected view has ' +
                     'not yet been saved')
             for k, v in enumerate(parameters):
-                parameters[k] = v.replace('%CWD%', dir_)
+                for old, new in replaces.items():
+                    v = v.replace(old, new)
+                parameters[k] = v
             args = [TerminalSelector.get()]
             args.extend(parameters)
             encoding = locale.getpreferredencoding(do_setlocale=True)

--- a/Terminal.py
+++ b/Terminal.py
@@ -103,6 +103,9 @@ class TerminalSelector():
 class TerminalCommand():
     def get_path(self, paths):
         if paths:
+            for path in paths:
+                if path in self.window.active_view().file_name():
+                    return path
             return paths[0]
         elif self.window.active_view():
             return self.window.active_view().file_name()

--- a/Terminal.py
+++ b/Terminal.py
@@ -104,7 +104,7 @@ class TerminalCommand():
     def get_path(self, paths):
         if paths:
             for path in paths:
-                if path in self.window.active_view().file_name():
+                if os.path.expanduser(path) in self.window.active_view().file_name():
                     return path
             return paths[0]
         elif self.window.active_view():
@@ -133,6 +133,7 @@ class TerminalCommand():
             args = [TerminalSelector.get()]
             args.extend(parameters)
             encoding = locale.getpreferredencoding(do_setlocale=True)
+            dir_ = os.path.expanduser(dir_)
             if sys.version_info >= (3,):
                 cwd = dir_
             else:


### PR DESCRIPTION
This pull request allows to use the filename and the line number in the command line.

Use case: 
tig blame Terminal.py +53
open the blame view of file Terminal.py at line 53

This can be configured in the commands with:
{ "keys": ["ctrl+shift+b"], "command": "open_terminal", "args": {"parameters": ["-e", "tig blame %FILE% +%LINE%", "--working-directory=%CWD%"]} },