### PR TITLE
Added support for Linux Mint/Cinnamon. Fixes #61

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -84,10 +84,10 @@ class TerminalSelector():
 
         else:
             ps = 'ps -eo comm | grep -E "gnome-session|ksmserver|' + \
-                'xfce4-session" | grep -v grep'
+                'xfce4-session|cinnamon-sessio" | grep -v grep'
             wm = [x.replace("\n", '') for x in os.popen(ps)]
             if wm:
-                if wm[0] == 'gnome-session':
+                if wm[0] == 'gnome-session' or wm[0] == 'cinnamon-sessio':
                     default = 'gnome-terminal'
                 elif wm[0] == 'xfce4-session':
                     default = 'terminal'


### PR DESCRIPTION
As mentioned in #61, Linux Mint uses Cinnamon over Gnome for its desktop. However, instead of `xterm`, it uses `gnome-terminal` as its default. In this PR:
- Add support for Linux Mint/Cinnamon with default of `gnome-terminal`
