### PR TITLE
Executable name for xfce4

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -90,7 +90,7 @@ class TerminalSelector():
                 if wm[0] == 'gnome-session':
                     default = 'gnome-terminal'
                 elif wm[0] == 'xfce4-session':
-                    default = 'terminal'
+                    default = 'xfce4-terminal'
                 elif wm[0] == 'ksmserver':
                     default = 'konsole'
             if not default:


### PR DESCRIPTION
xfce4-terminal is the correct name for the terminal that comes with xfce4, I believe. At least, it fixes the error I got.