### PR TITLE
Ability to open a new Tab in current iTerm window

### DIFF
--- a/iTerm.sh
+++ b/iTerm.sh
@@ -1,39 +1,40 @@
 #!/bin/bash
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
-NEWWINDOW=0
+VERSION=$(sw_vers -productVersion)
 
-while [ "$1" != "" ]; do
-	case $1 in
-		--openNewWindow )   NEWWINDOW=1
-												;;
-		--openNewTab )      NEWWINDOW=0
-												;;
-	esac
-	shift
-done
+if (( $(expr $VERSION '<' 10.7) )); then
+	RUNNING=$(osascript<<END
+	tell application "System Events"
+	    count(processes whose name is "iTerm")
+	end tell
+END
+)
+else
+	RUNNING=1
+fi
 
-if (( $NEWWINDOW )); then
-	osascript &>/dev/null <<EOF
+if (( $RUNNING )); then
+	osascript<<END
 	tell application "iTerm"
+		activate
 		set term to (make new terminal)
 		tell term
-			launch session "Default Session"
-			tell the last session
+			set sess to (launch session "Default Session")
+			tell sess
 				write text "$CD_CMD"
 			end tell
 		end tell
 	end tell
-EOF
+END
 else
-	osascript &>/dev/null <<EOF
+	osascript<<END
 	tell application "iTerm"
-		tell current terminal
-			launch session "Default Session"
-			tell the last session
-				write text "$CD_CMD"
-			end tell
+		activate
+		set sess to the first session of the first terminal
+		tell sess
+			write text "$CD_CMD"
 		end tell
 	end tell
-EOF
+END
 fi

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -2,14 +2,14 @@
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
 VERSION=$(sw_vers -productVersion)
-NEWTAB=0
+OPEN_IN_TAB=0
 
 while [ "$1" != "" ]; do
 	PARAM=`echo $1 | awk -F= '{print $1}'`
 	VALUE=`echo $1 | awk -F= '{print $2}'`
 	case $PARAM in
-		-t | --tab)
-			NEWTAB=1
+		--open-in-tab)
+			OPEN_IN_TAB=1
 			;;
 	esac
 	shift
@@ -18,7 +18,7 @@ done
 if (( $(expr $VERSION '<' 10.7) )); then
 	RUNNING=$(osascript<<END
 	tell application "System Events"
-		count(processes whose name is "iTerm")
+	    count(processes whose name is "iTerm")
 	end tell
 END
 )
@@ -38,7 +38,7 @@ if (( ! $RUNNING )); then
 	end tell
 END
 else
-	if (( $NEWTAB )); then
+	if (( $OPEN_IN_TAB )); then
 		osascript &>/dev/null <<EOF
 		tell application "iTerm"
 			tell current terminal

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -2,14 +2,13 @@
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
 VERSION=$(sw_vers -productVersion)
-NEWWINDOW=0
+NEWTAB=0
 
 while [ "$1" != "" ]; do
 	case $1 in
-		--openNewWindow )   NEWWINDOW=1
-												;;
-		--openNewTab )      NEWWINDOW=0
-												;;
+		--openNewTab)
+			NEWTAB=1
+			;;
 	esac
 	shift
 done
@@ -17,7 +16,7 @@ done
 if (( $(expr $VERSION '<' 10.7) )); then
 	RUNNING=$(osascript<<END
 	tell application "System Events"
-			count(processes whose name is "iTerm")
+		count(processes whose name is "iTerm")
 	end tell
 END
 )
@@ -37,11 +36,10 @@ if (( ! $RUNNING )); then
 	end tell
 END
 else
-	if (( $NEWWINDOW )); then
+	if (( $NEWTAB )); then
 		osascript &>/dev/null <<EOF
 		tell application "iTerm"
-			set term to (make new terminal)
-			tell term
+			tell current terminal
 				launch session "Default Session"
 				tell the last session
 					write text "$CD_CMD"
@@ -52,7 +50,8 @@ EOF
 	else
 		osascript &>/dev/null <<EOF
 		tell application "iTerm"
-			tell current terminal
+			set term to (make new terminal)
+			tell term
 				launch session "Default Session"
 				tell the last session
 					write text "$CD_CMD"

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -5,9 +5,9 @@ VERSION=$(sw_vers -productVersion)
 OPEN_IN_TAB=0
 
 while [ "$1" != "" ]; do
-	PARAM=`echo $1 | awk -F= '{print $1}'`
-	VALUE=`echo $1 | awk -F= '{print $2}'`
-	case $PARAM in
+	PARAM="$1"
+	VALUE="$2"
+	case "$PARAM" in
 		--open-in-tab)
 			OPEN_IN_TAB=1
 			;;

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -5,8 +5,10 @@ VERSION=$(sw_vers -productVersion)
 NEWTAB=0
 
 while [ "$1" != "" ]; do
-	case $1 in
-		--openNewTab)
+	PARAM=`echo $1 | awk -F= '{print $1}'`
+	VALUE=`echo $1 | awk -F= '{print $2}'`
+	case $PARAM in
+		-t | --tab)
 			NEWTAB=1
 			;;
 	esac

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -1,40 +1,39 @@
 #!/bin/bash
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
-VERSION=$(sw_vers -productVersion)
+NEWWINDOW=0
 
-if (( $(expr $VERSION '<' 10.7) )); then
-	RUNNING=$(osascript<<END
-	tell application "System Events"
-	    count(processes whose name is "iTerm")
-	end tell
-END
-)
-else
-	RUNNING=1
-fi
+while [ "$1" != "" ]; do
+	case $1 in
+		--openNewWindow )   NEWWINDOW=1
+												;;
+		--openNewTab )      NEWWINDOW=0
+												;;
+	esac
+	shift
+done
 
-if (( $RUNNING )); then
-	osascript<<END
+if (( $NEWWINDOW )); then
+	osascript &>/dev/null <<EOF
 	tell application "iTerm"
-		activate
 		set term to (make new terminal)
 		tell term
-			set sess to (launch session "Default Session")
-			tell sess
+			launch session "Default Session"
+			tell the last session
 				write text "$CD_CMD"
 			end tell
 		end tell
 	end tell
-END
+EOF
 else
-	osascript<<END
+	osascript &>/dev/null <<EOF
 	tell application "iTerm"
-		activate
-		set sess to the first session of the first terminal
-		tell sess
-			write text "$CD_CMD"
+		tell current terminal
+			launch session "Default Session"
+			tell the last session
+				write text "$CD_CMD"
+			end tell
 		end tell
 	end tell
-END
+EOF
 fi

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -2,11 +2,22 @@
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
 VERSION=$(sw_vers -productVersion)
+NEWWINDOW=0
+
+while [ "$1" != "" ]; do
+	case $1 in
+		--openNewWindow )   NEWWINDOW=1
+												;;
+		--openNewTab )      NEWWINDOW=0
+												;;
+	esac
+	shift
+done
 
 if (( $(expr $VERSION '<' 10.7) )); then
 	RUNNING=$(osascript<<END
 	tell application "System Events"
-	    count(processes whose name is "iTerm")
+			count(processes whose name is "iTerm")
 	end tell
 END
 )
@@ -14,27 +25,40 @@ else
 	RUNNING=1
 fi
 
-if (( $RUNNING )); then
+if (( ! $RUNNING )); then
 	osascript<<END
 	tell application "iTerm"
-		activate
-		set term to (make new terminal)
-		tell term
-			set sess to (launch session "Default Session")
-			tell sess
+		tell current terminal
+			launch session "Default Session"
+			tell the last session
 				write text "$CD_CMD"
 			end tell
 		end tell
 	end tell
 END
 else
-	osascript<<END
-	tell application "iTerm"
-		activate
-		set sess to the first session of the first terminal
-		tell sess
-			write text "$CD_CMD"
+	if (( $NEWWINDOW )); then
+		osascript &>/dev/null <<EOF
+		tell application "iTerm"
+			set term to (make new terminal)
+			tell term
+				launch session "Default Session"
+				tell the last session
+					write text "$CD_CMD"
+				end tell
+			end tell
 		end tell
-	end tell
-END
+EOF
+	else
+		osascript &>/dev/null <<EOF
+		tell application "iTerm"
+			tell current terminal
+				launch session "Default Session"
+				tell the last session
+					write text "$CD_CMD"
+				end tell
+			end tell
+		end tell
+EOF
+	fi
 fi


### PR DESCRIPTION
A new parameter can be used to instruct to open a new tab in the current window or to open a new window altogether. Also, a few bug corrections on the RUNNING variable.