### PR TITLE
Migrate to subprocess.call

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -85,7 +85,9 @@ class TerminalSelector():
         else:
             ps = 'ps -eo comm | grep -E "gnome-session|ksmserver|' + \
                 'xfce4-session" | grep -v grep'
-            wm = [x.replace("\n", '') for x in os.popen(ps)]
+            subprocess.call(ps)
+            wm = [x.replace("\n", '') for x in subprocess.call(ps)]
+            
             if wm:
                 if wm[0] == 'gnome-session':
                     default = 'gnome-terminal'

--- a/Terminal.py
+++ b/Terminal.py
@@ -85,7 +85,6 @@ class TerminalSelector():
         else:
             ps = 'ps -eo comm | grep -E "gnome-session|ksmserver|' + \
                 'xfce4-session" | grep -v grep'
-            subprocess.call(ps)
             wm = [x.replace("\n", '') for x in subprocess.call(ps)]
             
             if wm:


### PR DESCRIPTION
the current implementation of popen does not allow for the wait() so we do not have any errors. With subprocess.call it includes the wait anyway. Also popen is depreciated to subprocess.call 