### PR TITLE
Add ConEmu64 executable

### DIFF
--- a/ConEmu64.bat
+++ b/ConEmu64.bat
@@ -1,0 +1,1 @@
+ConEmu64.exe


### PR DESCRIPTION
How to use:
 1. Add ConEmu folder to path ("c:\Program Files\ConEmu\" for non-portable version).
 2. Set terminal option to "ConEmu64.bat".