### PR TITLE
fish shell compatibility in iTerm

### DIFF
--- a/Terminal.sh
+++ b/Terminal.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-CD_CMD="cd "\\\"$(pwd)\\\""; clear"
+CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
+if echo "$SHELL" | grep -E "/fish$" &> /dev/null; then
+  CD_CMD="cd "\\\"$(pwd)\\\""; and clear"
+fi
 VERSION=$(sw_vers -productVersion)
 if (( $(expr $VERSION '<' 10.7.0) )); then
 	IN_WINDOW="in window 1"

--- a/iTerm.sh
+++ b/iTerm.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
+if echo "$SHELL" | grep -E "/fish$" &> /dev/null; then
+  CD_CMD="cd "\\\"$(pwd)\\\""; and clear"
+fi
 VERSION=$(sw_vers -productVersion)
 
 if (( $(expr $VERSION '<' 10.7) )); then


### PR DESCRIPTION
Use semicolon for fish compatibility.

Same as in #40, but in `iTerm.sh`.