### PR TITLE
Added fix for multiple project folders with same base path and starting name

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -170,7 +170,10 @@ class OpenTerminalProjectFolderCommand(sublime_plugin.WindowCommand,
         if not path:
             return
 
-        folders = [x for x in self.window.folders() if path.find(x) == 0][0:1]
+        # DEV: We require separator to be appended since `/hello` and `/hello-world`
+        #   would both match a file in `/hello` without it
+        #   For more info, see https://github.com/wbond/sublime_terminal/issues/86
+        folders = [x for x in self.window.folders() if path.find(x + os.sep) == 0][0:1]
 
         command = OpenTerminalCommand(self.window)
         command.run(folders, parameters=parameters)


### PR DESCRIPTION
As reported in #86, we have a regression when project folders have the same base path and starting name (e.g. `/hello` and `/hello-world` will both match as the folder for `/hello-world/moon.txt` since they both start off the path). In this PR:

- Added extra separator to check for when a path starts
- Added comment about regression
- Fixes #86 

**Notes:**

I am mostly opening this PR for keeping a record of new items (since we have no CHANGELOG). I don't feel like this needs to be run by wbond.