### PR TITLE
remapped 'open_terminal' command  #17

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-	{ "keys": ["super+shift+t"], "command": "open_terminal" },
+	{ "keys": ["shift+alt+t"], "command": "open_terminal" },
 	{ "keys": ["super+shift+alt+t"], "command": "open_terminal_project_folder" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [
-	{ "keys": ["ctrl+shift+t"], "command": "open_terminal" },
+	{ "keys": ["shift+alt+t"], "command": "open_terminal" },
 	{ "keys": ["ctrl+shift+alt+t"], "command": "open_terminal_project_folder" }
 ]


### PR DESCRIPTION
I used `shift+alt+t` because `ctrl+alt+t` conflicts with [Text Pastry](https://packagecontrol.io/packages/Text%20Pastry)
