### PR TITLE
Open Terminal.app using OS X 'open' command

### DIFF
--- a/Terminal.sh
+++ b/Terminal.sh
@@ -1,27 +1,2 @@
 #!/bin/bash
-
-CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
-if echo "$SHELL" | grep -E "/fish$" &> /dev/null; then
-  CD_CMD="cd "\\\"$(pwd)\\\""; and clear"
-fi
-VERSION=$(sw_vers -productVersion)
-if (( $(expr $VERSION '<' 10.7.0) )); then
-	IN_WINDOW="in window 1"
-fi
-osascript<<END
-try
-	tell application "System Events"
-		if (count(processes whose name is "Terminal")) is 0 then
-			tell application "Terminal"
-				activate
-				do script "$CD_CMD" $IN_WINDOW
-			end tell
-		else
-			tell application "Terminal"
-				activate
-				do script "$CD_CMD"
-			end tell
-		end if
-	end tell
-end try
-END
+/usr/bin/open "$PWD" -a /Applications/Utilities/Terminal.app


### PR DESCRIPTION
The advantages are speed and no command being executed inside the terminal window.
The terminal is always open in a new window.

Don't know if this is exactly the same as before though. 

It's fine for me so I'm making the proposal :)