### PR TITLE
Repaired handling of temporary views in Sublime Text 3

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -117,7 +117,9 @@ class TerminalCommand():
     def get_path(self, paths):
         if paths:
             return paths[0]
-        elif self.window.active_view():
+        # DEV: On ST3, there is always an active view.
+        #   Be sure to check that it's a file with a path (not temporary view)
+        elif self.window.active_view() and self.window.active_view().file_name():
             return self.window.active_view().file_name()
         elif self.window.folders():
             return self.window.folders()[0]


### PR DESCRIPTION
As noted in #62, there is an issue in ST3 where attempting to use "Terminal: Open" or "Terminal: Open in project folder" fails to work when no files are open.

This is being caused by ST3 always having an active view (i.e. a temporary view so you can start typing at any time). As a result, when we resolve the file name of this active view, we get `None`:

```
>>> str(view.file_name())
'None'
```

We were exiting early with this `None` when we really want to skip to the next `elif` in our path resolver. This PR fixes that. In this PR:

- Updated `elif` for active view's file name to require a file name

/cc @wbond 