### PR TITLE
Improved OSError handling

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -1,5 +1,6 @@
 import sublime
 import sublime_plugin
+import errno
 import os
 import sys
 import subprocess
@@ -144,9 +145,16 @@ class TerminalCommand():
             subprocess.Popen(args, cwd=cwd)
 
         except (OSError) as exception:
-            print(str(exception))
-            sublime.error_message('Terminal: The terminal ' +
-                TerminalSelector.get() + ' was not found')
+            # By default, use and log the message from our error
+            message = str(exception)
+            print(message)
+
+            # If the terminal wasn't found, then use a better message
+            if exception.errno == errno.ENOENT:
+                message = 'Terminal: The terminal ' + TerminalSelector.get() + ' was not found'
+
+            # Notify the user of the issue
+            sublime.error_message(message)
         except (Exception) as exception:
             sublime.error_message('Terminal: ' + str(exception))
 


### PR DESCRIPTION
As mentioned in #103, we are conflating `ENOENT` with the rest of potential `OSError` errors. Since it's hard to predict/provide more clear messages for all variations, we have chosen to only cover `ENOENT` and pass through other errors to the user.

In this PR:

- Updated `OSError` handling to use exception message by default but provide better messaging on `ENOENT`

/cc @wbond 