### PR TITLE
Fix custom parameters are not working in an open_terminal command

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -157,7 +157,8 @@ class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
         if not path:
             return
 
-        parameters = get_setting('parameters', [])
+        if parameters is None:
+            parameters = get_setting('parameters', [])
 
         if os.path.isfile(path):
             path = os.path.dirname(path)


### PR DESCRIPTION
The following key binding should work as its [doc](https://github.com/wbond/sublime_terminal#custom-parameters) but it does not. The `parameters` is always overwritten by user settings.
```javascript
{
    "keys": ["f5"],
    "command": "open_terminal",
    "args": {
        "parameters": ["-NoExit", "-File", "C:/MyFile.ps1"]
    }
},
```

In `MyFile.ps1` (just print some messages),
```powershell
get-host
```

--

Ref: https://www.reddit.com/r/SublimeText/comments/4bt2fk/launch_powershell_with_a_specific_command_by/