### PR TITLE
[FIX] gnome-terminal for gnome-session

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -96,7 +96,7 @@ class TerminalSelector():
                 'xfce4-session|lxsession|mate-panel|cinnamon-sessio" | grep -v grep'
             wm = [x.replace("\n", '') for x in os.popen(ps)]
             if wm:
-                if wm[0] == 'gnome-session' or wm[0] == 'cinnamon-sessio':
+                if 'gnome-session' in wm[0] or wm[0] == 'cinnamon-sessio':
                     default = 'gnome-terminal'
                 elif wm[0] == 'xfce4-session':
                     default = 'xfce4-terminal'


### PR DESCRIPTION
From Ubuntu 16.04,  `gnome-session` is now returned as `gnome-session-b` when performing `ps -eo comm`.

To check, on Ubuntu 16.04, just run the following command (which is the above `ps` command, shortened for this case only):
`ps -eo comm | grep -E "gnome-session" | grep -v grep`
it returns
`gnome-session-b`

This patch takes care of the retro-compatibility, it will work either if it's `gnome-session` which is returned or `gnome-session-b`