### PR TITLE
Disable 'open terminal here' command for unsaved documents

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -165,6 +165,9 @@ class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
 
         self.run_terminal(path, parameters)
 
+    def is_enabled(self):
+        return bool(self.window.active_view() and self.window.active_view().file_name())
+
 
 class OpenTerminalProjectFolderCommand(sublime_plugin.WindowCommand,
         TerminalCommand):


### PR DESCRIPTION
Fixes https://github.com/wbond/sublime_terminal/issues/119
