### PR TITLE
Added iTerm2 script

### DIFF
--- a/iTerm2.sh
+++ b/iTerm2.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+CD_CMD="cd "\\\"$(pwd)\\\"" && clear"
+
+if echo "$SHELL" | grep -E "/fish$" &> /dev/null; then
+  CD_CMD="cd "\\\"$(pwd)\\\""; and clear"
+fi
+
+VERSION=$(sw_vers -productVersion)
+OPEN_IN_TAB=0
+
+while [ "$1" != "" ]; do
+  PARAM="$1"
+  VALUE="$2"
+  case "$PARAM" in
+    --open-in-tab)
+      OPEN_IN_TAB=1
+      ;;
+  esac
+  shift
+done
+
+RUNNING=$(osascript<<END
+  tell application "System Events"
+    count(processes whose name is "iTerm2")
+  end tell
+END
+)
+
+echo $RUNNING
+
+if (( $RUNNING )); then
+  if (( $OPEN_IN_TAB )); then
+    osascript &>/dev/null <<EOF
+      tell application "iTerm2"
+        tell current window
+          create tab with profile "Default"
+          write text "$CD_CMD"
+        end tell
+      end tell
+EOF
+  else
+    osascript &>/dev/null <<EOF
+      tell application "iTerm2"
+        create window with profile "Default"
+        write text "$CD_CMD"
+      end tell
+EOF
+  fi
+else
+  osascript<<END
+    tell application "iTerm2"
+      create window with profile "Default"
+      write text "$CD_CMD"
+    end tell
+END
+fi

--- a/readme.md
+++ b/readme.md
@@ -55,17 +55,25 @@ Here are some example setups:
 
 #### iTerm on OS X
 
-```js
-{
-  "terminal": "iTerm.sh"
-}
-```
+* iTerm
+  ```js
+  {
+    "terminal": "iTerm.sh"
+  }
+  ```
+
+* iTerm2
+  ```js
+  {
+    "terminal": "iTerm2.sh"
+  }
+  ```
 
 #### iTerm on OS X with tabs
 
 ```js
 {
-  "terminal": "iTerm.sh",
+  "terminal": "iTerm.sh", # According to your version of iTerm.
   "parameters": ["--open-in-tab"]
 }
 ```


### PR DESCRIPTION
I don't know if this happens to just me or more people, but installing the vanilla version of the Package doesn't seem to work with iTerm2.

Here's a port of the iTerm.sh script to iTerm2 commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wbond/sublime_terminal/124)
<!-- Reviewable:end -->
