### PR TITLE
Documented missing changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # changelog
 
+## 1.12.0
+
+ - Fixed gnome-terminal support via @beledouxdenis in #115
+
+## 1.11.0
+
+ - Fixed custom parameters functionality via @jfcherng in #112
+
 ## 1.10.1
 
  - Replaced `readme.creole` with `readme.md` based off of website


### PR DESCRIPTION
While landing #98, I noticed we didn't have CHANGELOG updates for `1.11.0` and `1.12.0`. This PR repairs that. In this PR:

- Added missing CHANGELOG notes

Going to be cowboy landing this due to its simplicity