### PR TITLE
Default reopen last file keyboard shortcut conflict

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-	{ "keys": ["super+shift+t"], "command": "open_terminal" },
+	{ "keys": ["ctrl+shift+t"], "command": "open_terminal" },
 	{ "keys": ["super+shift+alt+t"], "command": "open_terminal_project_folder" }
 ]


### PR DESCRIPTION
Per https://github.com/wbond/sublime_terminal/pull/92 and https://github.com/wbond/sublime_terminal/issues/17

It seems like there is consensus that the shortcut should not conflict with the default Sublime Text one. Coincidentally, super+shift+t also reopens the last tab in Chrome. Reopen is probably more what people expect.
