### PR TITLE
Add info on iTerm2 in Terminal.sublime-settings

### DIFF
--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -1,6 +1,6 @@
 {
-	// The command to execute for the terminal, leave blank for the OS default
-	// On OS X the terminal can be set to iTerm.sh to execute iTerm (or iTerm2-v3.sh for iTerm2 build 3.x)
+	// The command to execute for the terminal, leave blank for the OS default and see
+	// https://github.com/wbond/sublime_terminal#examples for more details
 	"terminal": "",
 
 	// A list of default parameters to pass to the terminal, this can be

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -1,6 +1,6 @@
 {
 	// The command to execute for the terminal, leave blank for the OS default
-	// On OS X the terminal can be set to iTerm.sh to execute iTerm
+	// On OS X the terminal can be set to iTerm.sh to execute iTerm (or iTerm2-v3.sh for iTerm2 build 3.x)
 	"terminal": "",
 
 	// A list of default parameters to pass to the terminal, this can be


### PR DESCRIPTION
This way the user don't get stuck for a while trying to use iTerm.sh for new installations that in majority uses iTerm2 instead of iTerm1.