### PR TITLE
remove colour imposition

### DIFF
--- a/PS.ps1
+++ b/PS.ps1
@@ -12,7 +12,5 @@ $newsize.width = 120
 $pswindow.windowsize = $newsize
 
 $pswindow.windowtitle = "Windows Powershell"
-$pswindow.foregroundcolor = "DarkYellow"
-$pswindow.backgroundcolor = "DarkMagenta"
 
 cls


### PR DESCRIPTION
Setting colours here overrides user specified theme settings.

Suggest that the documentation direct users to use `concfg` to create powershell theme settings.