### PR TITLE
Unset LD_PRELOAD before launch.

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -141,7 +141,11 @@ class TerminalCommand():
                 cwd = dir_
             else:
                 cwd = dir_.encode(encoding)
-            subprocess.Popen(args, cwd=cwd)
+            env = os.environ.copy()
+            if 'LD_PRELOAD' in env:
+                ld_preload = env.pop('LD_PRELOAD')
+                print('Terminal: LD_PRELOAD ("{}") is unset before launch'.format(ld_preload))
+            subprocess.Popen(args, cwd=cwd, env=env)
 
         except (OSError) as exception:
             print(str(exception))

--- a/Terminal.py
+++ b/Terminal.py
@@ -4,7 +4,6 @@ import os
 import sys
 import subprocess
 import locale
-import string
 
 if os.name == 'nt':
     try:
@@ -114,14 +113,6 @@ class TerminalSelector():
         return default
 
 
-class SafeFormatter(string.Formatter):
-    def get_value(self, key, args, kwds):
-        if isinstance(key, str):
-            return kwds.get(key, '')
-        else:
-            Formatter.get_value(key, args, kwds)
-
-
 class TerminalCommand():
     def get_path(self, paths):
         if paths:
@@ -154,12 +145,11 @@ class TerminalCommand():
 
             env_setting = get_setting('env')
             env = os.environ.copy()
-            fmt = SafeFormatter()
             for k in env_setting:
                 if env_setting[k] is None:
                     env.pop(k, None)
                 else:
-                    env[k] = fmt.format(env_setting[k], **os.environ)
+                    env[k] = env_setting[k]
 
             subprocess.Popen(args, cwd=cwd, env=env)
 

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -13,5 +13,5 @@
     // terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
     // null value to indicate that the environment variable should be unset. Use named
     // format spec to reference any existing environment variable (e.g. {"PATH":"{PATH}:."}).
-    "env": {}
+	"env": {}
 }

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -11,7 +11,6 @@
 
 	// An environment variables changeset. Default environment variables used for the
 	// terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
-	// null value to indicate that the environment variable should be unset. Use named
-	// format spec to reference any existing environment variable (e.g. {"PATH":"{PATH}:."}).
+	// null value to indicate that the environment variable should be unset.
 	"env": {}
 }

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -9,9 +9,9 @@
 	// commands
 	"parameters": [],
 
-    // An environment variables changeset. Default environment variables used for the
-    // terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
-    // null value to indicate that the environment variable should be unset. Use named
-    // format spec to reference any existing environment variable (e.g. {"PATH":"{PATH}:."}).
+	// An environment variables changeset. Default environment variables used for the
+	// terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
+	// null value to indicate that the environment variable should be unset. Use named
+	// format spec to reference any existing environment variable (e.g. {"PATH":"{PATH}:."}).
 	"env": {}
 }

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -7,5 +7,11 @@
 	// overridden by passing the "parameters" key with a list value to the args
 	// dict when calling the "open_terminal" or "open_terminal_project_folder"
 	// commands
-	"parameters": []
+	"parameters": [],
+
+    // An environment variables changeset. Default environment variables used for the
+    // terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
+    // null value to indicate that the environment variable should be unset. Use named
+    // format spec to reference any existing environment variable (e.g. {"PATH":"{PATH}:."}).
+    "env": {}
 }

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,7 @@ The default settings can be viewed by accessing the ***Preferences > Package Set
      - *Default:* ***[]***
  - **env**
      - The environment variables changeset. Default environment variables used when invoking the terminal are inherited from sublime.
-     - Use `null` to indicate that the environment variable should be unset.
-     - Use named format spec to reference any existing environment variable (e.g. `{"PATH":"{PATH}:."}`).
+     - The changeset may be used to overwrite/unset environment variables. Use `null` to indicate that the environment variable should be unset.
      - *Default:* ***{}***
 
 ### Examples

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,11 @@ The default settings can be viewed by accessing the ***Preferences > Package Set
  - **parameters**
      - The parameters to pass to the terminal. These parameters will be used if no [custom parameters](#custom-parameters) are passed via a key binding.
      - *Default:* ***[]***
+ - **env**
+     - The environment variables changeset. Default environment variables used when invoking the terminal are inherited from sublime.
+     - Use `null` to indicate that the environment variable should be unset.
+     - Use named format spec to reference any existing environment variable (e.g. `{"PATH":"{PATH}:."}`).
+     - *Default:* ***{}***
 
 ### Examples
 
@@ -49,7 +54,9 @@ Here are some example setups:
 
 ```js
 {
-  "terminal": "xterm"
+  "terminal": "xterm",
+  // Include "." in environment variable PATH, and unset LD_PRELOAD
+  "env": {"PATH": "{PATH}:.", "LD_PRELOAD": null}
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Here are some example setups:
 
 ```js
 {
-  "terminal": "xterm",
+  "terminal": "xterm"
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -55,10 +55,17 @@ Here are some example setups:
 ```js
 {
   "terminal": "xterm",
-  // Include "." in environment variable PATH, and unset LD_PRELOAD
-  "env": {"PATH": "{PATH}:.", "LD_PRELOAD": null}
 }
 ```
+
+#### gnome-terminal for CJK users on GNU/Linux
+
+```js
+{
+  "terminal": "gnome-terminal",
+  // Unset LD_PRELOAD which may cause problems for sublime with imfix
+  "env": {"LD_PRELOAD": null}
+}
 
 #### iTerm on OS X
 


### PR DESCRIPTION
Many CJK sublime users use sublime-imfix.c (by jianzhong.huang@i-soft.com.cn & whitequark@whitequark.org) for input. This hack uses LD_PRELOAD to provide a GTK+-2.0 patch, but LD_PRELOAD may be passed to the invoked terminal and may cause problems. For gnome-terminal, the error message is: `GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported`.

This commit unsets LD_PRELOAD before lauching the terminal.