### PR TITLE
Moved from os.putenv to os.environ to fix Windows Powershell support

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -82,7 +82,7 @@ class TerminalSelector():
                 buf = create_unicode_buffer(512)
                 if windll.kernel32.GetShortPathNameW(sublime_terminal_path, buf, len(buf)):
                     sublime_terminal_path = buf.value
-                os.putenv('sublime_terminal_path', sublime_terminal_path.replace(' ', '` '))
+                os.environ['sublime_terminal_path'] = sublime_terminal_path.replace(' ', '` ')
             else :
                 default = os.environ['SYSTEMROOT'] + '\\System32\\cmd.exe'
 


### PR DESCRIPTION
As reported in #151 our change in #150 caused us to lose `os.putenv` being absorbed when our `run_terminal` command is used. As a quick fix to this, we are moving from `os.putenv` to `os.environ`. In this PR:

- Moved from `os.putenv` to `os.environ`
- Fixes #151 

**Notes:**

Ideally we would have a static store for environment overrides or pass back terminal and environment from `TerminalSelector.get()`. However, this is equally as dirty/functional as the original implementation.

/cc @wbond 