### PR TITLE
Added fallback for env setting

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -143,7 +143,7 @@ class TerminalCommand():
             else:
                 cwd = dir_.encode(encoding)
 
-            env_setting = get_setting('env')
+            env_setting = get_setting('env', {})
             env = os.environ.copy()
             for k in env_setting:
                 if env_setting[k] is None:


### PR DESCRIPTION
We missed adding a fallback for `env` in #152. This caused an error reported in #154. In this PR;

- Added fallback for `env` setting
- Fixes #152 