### PR TITLE
Added environment normalization

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -143,6 +143,7 @@ class TerminalCommand():
             else:
                 cwd = dir_.encode(encoding)
 
+            # Copy over environment settings onto parent environment
             env_setting = get_setting('env', {})
             env = os.environ.copy()
             for k in env_setting:
@@ -151,6 +152,17 @@ class TerminalCommand():
                 else:
                     env[k] = env_setting[k]
 
+            # Normalize environment settings for ST2
+            # https://github.com/wbond/sublime_terminal/issues/154
+            # http://stackoverflow.com/a/4987414
+            for k in env:
+                if not isinstance(env[k], str):
+                    if isinstance(env[k], unicode):
+                        env[k] = env[k].encode('utf8')
+                    else:
+                        print('Unsupported environment variable type. Expected "str" or "unicode"', env[k])
+
+            # Run our process
             subprocess.Popen(args, cwd=cwd, env=env)
 
         except (OSError) as exception:


### PR DESCRIPTION
We improperly eagerly closed #154 with a separate issue. It turns out our injection of `sublime_terminal_path` in Python 2 (ST2) as a unicode string was causing issues as `Popen` only wants `str` strings. In this PR:

- Added normalization for environment from `unicode` to `str`

**Notes:**

We could move from `create_unicode_buffer` to `create_string_buffer` but I have a feeling that could undo existing patched regressions and this seems like it should work fine. Tested on ST2 on Windows and ST3 on Linux
