### PR TITLE
Added support for elementary OS' pantheon-terminal

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -96,10 +96,14 @@ class TerminalSelector():
                 'xfce4-session|lxsession|mate-panel|cinnamon-sessio)" | grep -v grep'
             wm = [x.replace("\n", '') for x in os.popen(ps)]
             if wm:
+                # elementary OS: `/usr/lib/gnome-session/gnome-session-binary --session=pantheon`
                 # Gnome: `gnome-session` or `gnome-session-binary`
                 # Linux Mint Cinnamon: `cinnamon-session --session cinnamon`
                 if wm[0].startswith('gnome-session') or wm[0].startswith('cinnamon-sessio'):
-                    default = 'gnome-terminal'
+                    if 'pantheon' in wm[0]:
+                        default = 'pantheon-terminal'
+                    else:
+                        default = 'gnome-terminal'
                 elif wm[0].startswith('xfce4-session'):
                     default = 'xfce4-terminal'
                 elif wm[0].startswith('ksmserver'):

--- a/Terminal.py
+++ b/Terminal.py
@@ -92,19 +92,21 @@ class TerminalSelector():
                 os.chmod(default, 0o755)
 
         else:
-            ps = 'ps -eo comm | grep -E "gnome-session|ksmserver|' + \
-                'xfce4-session|lxsession|mate-panel|cinnamon-sessio" | grep -v grep'
+            ps = 'ps -eo comm,args | grep -E "^(gnome-session|ksmserver|' + \
+                'xfce4-session|lxsession|mate-panel|cinnamon-sessio)" | grep -v grep'
             wm = [x.replace("\n", '') for x in os.popen(ps)]
             if wm:
-                if 'gnome-session' in wm[0] or wm[0] == 'cinnamon-sessio':
+                # Gnome: `gnome-session` or `gnome-session-binary`
+                # Linux Mint Cinnamon: `cinnamon-session --session cinnamon`
+                if wm[0].startswith('gnome-session') or wm[0].startswith('cinnamon-sessio'):
                     default = 'gnome-terminal'
-                elif wm[0] == 'xfce4-session':
+                elif wm[0].startswith('xfce4-session'):
                     default = 'xfce4-terminal'
-                elif wm[0] == 'ksmserver':
+                elif wm[0].startswith('ksmserver'):
                     default = 'konsole'
-                elif wm[0] == 'lxsession':
+                elif wm[0].startswith('lxsession'):
                     default = 'lxterminal'
-                elif wm[0] == 'mate-panel':
+                elif wm[0].startswith('mate-panel'):
                     default = 'mate-terminal'
             if not default:
                 default = 'xterm'


### PR DESCRIPTION
As reported in #159, elementary OS is currently launching `gnome-terminal` when it should be launching `pantheon-terminal` (its default terminal). This is due to elementary OS using Gnome:

```
/usr/lib/gnome-session/gnome-session-binary --session=pantheon
```

We have repaired this by adding arguments to the `ps` output and looking for the `--session=pantheon` flag. In this PR:

- Added support for elementary OS' pantheon-terminal
- Fixes #159 

/cc @wbond 