### PR TITLE
Fixed inability to load OSX specific config file.

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -26,7 +26,7 @@ def get_setting(key, default=None):
     os_specific_settings = {}
     if os.name == 'nt':
         os_specific_settings = sublime.load_settings('Terminal (Windows).sublime-settings')
-    elif os.name == 'darwin':
+    elif sys.platform == 'darwin':
         os_specific_settings = sublime.load_settings('Terminal (OSX).sublime-settings')
     else:
         os_specific_settings = sublime.load_settings('Terminal (Linux).sublime-settings')


### PR DESCRIPTION
Fixes issue due to `os.name` returning `'posix'` instead of `'darwin'`. `sys.platform` does the right thing.

I didn't change all of the `os.name` calls to `sys.platform` as there appears to be multiple responses when running on Windows.