### PR TITLE
Support for `Run program in new prompt`.

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,5 @@
 [
 	{ "keys": ["ctrl+shift+t"], "command": "open_terminal" },
+	{ "keys": ["ctrl+shift+b"], "command": "terminal_build" },
 	{ "keys": ["ctrl+shift+alt+t"], "command": "open_terminal_project_folder" }
 ]

--- a/Terminal (Windows).sublime-settings
+++ b/Terminal (Windows).sublime-settings
@@ -1,0 +1,17 @@
+{
+    "parameters":
+    [
+        "$ext = [IO.Path]::GetExtension(%FILE%)\n",
+        "$file = %FILE%\n",
+        "switch ($ext){\n",
+
+        // >>>>>>>>>> add your command here <<<<<<<<<
+        ".py {python $file}\n",
+        ".nim {nim c -r $file}\n",
+
+
+        "default {Write-Host \"Please edit 'Terminal (Windows).sublime-settings' and add your support for file type: $ext\"}\n}\n",
+        "echo -----------------------------------------------------------\n",
+        "pause",
+    ]
+}

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,13 @@
 # Sublime Terminal
 
-Shortcuts and menu entries for opening a terminal at the current file, or the current root project folder in [Sublime Text](http://sublimetext.com/).
+Shortcuts and menu entries for opening a terminal at the current file, or the current root project folder in [Sublime Text](http://sublimetext.com/). Or build/run current
+ file in new terminal.  
 
 ## Features
 
  - Opens a terminal in the folder containing the currently edited file
  - Opens a terminal in the project folder containing the currently edited file
+ - Opens a terminal and build current file on Windows. For Linux/OSX [TerminalView](https://github.com/Wramberg/TerminalView) would be great.
 
 ## Installation
 
@@ -14,9 +16,11 @@ Download [Package Control](https://packagecontrol.io/) and use the *Package Cont
 ## Usage
 
  - **Open Terminal at File**
-     Press *ctrl+shift+t* on Windows and Linux, or *cmd+shift+t* on OS X
+     Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>t</kbd> on Windows and Linux, or *cmd+shift+t* on OS X
  - **Open Terminal at Project Folder**
-     Press *ctrl+alt+shift+t* on Windows and Linux, or *cmd+alt+shift+t* on OS X
+     Press <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>shift</kbd>+<kbd>t</kbd> on Windows and Linux, or *cmd+alt+shift+t* on OS X
+ - **Build in New Terminal**
+     Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>b</kbd> on Windows. Change to other keybindings if you want.
 
 In addition to the key bindings, terminals can also be opened via the editor context menu and the sidebar context menus.
 


### PR DESCRIPTION
E.g. Python `input()` is not possible within Sublime. Now we can build/run file in a new created prompt with one shortcut.  
Only work for Windows PowerShell currently. May not compatible with other Windows terminal.  
Feel free to ignore me if you think I'm wrong :)
