### PR TITLE
Support opening multiple terminal types (#16 and #197)

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -37,9 +37,9 @@ class TerminalSelector():
     default = None
 
     @staticmethod
-    def get():
+    def get(terminal_key):
         package_dir = os.path.join(sublime.packages_path(), installed_dir)
-        terminal = get_setting('terminal')
+        terminal = get_setting(terminal_key)
         if terminal:
             dir, executable = os.path.split(terminal)
             if not dir:
@@ -133,14 +133,14 @@ class TerminalCommand():
             sublime.error_message('Terminal: No place to open terminal to')
             return False
 
-    def run_terminal(self, dir_, parameters):
+    def run_terminal(self, dir_, terminal, parameters):
         try:
             if not dir_:
                 raise NotFoundError('The file open in the selected view has ' +
                     'not yet been saved')
             for k, v in enumerate(parameters):
                 parameters[k] = v.replace('%CWD%', dir_)
-            args = [TerminalSelector.get()]
+            args = [TerminalSelector.get(terminal)]
             args.extend(parameters)
 
             encoding = locale.getpreferredencoding(do_setlocale=True)
@@ -180,10 +180,13 @@ class TerminalCommand():
 
 
 class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
-    def run(self, paths=[], parameters=None):
+    def run(self, paths=[], terminal=None, parameters=None):
         path = self.get_path(paths)
         if not path:
             return
+
+        if terminal is None:
+            terminal = 'terminal'
 
         if parameters is None:
             parameters = get_setting('parameters', [])
@@ -191,7 +194,7 @@ class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
         if os.path.isfile(path):
             path = os.path.dirname(path)
 
-        self.run_terminal(path, parameters)
+        self.run_terminal(path, terminal, parameters)
 
 
 class OpenTerminalProjectFolderCommand(sublime_plugin.WindowCommand,

--- a/Terminal.py
+++ b/Terminal.py
@@ -180,7 +180,7 @@ class TerminalCommand():
 
 
 class OpenTerminalCommand(sublime_plugin.WindowCommand, TerminalCommand):
-    def run(self, paths=[], terminal=None, parameters=None):
+    def run(self, paths=[], parameters=None, terminal=None):
         path = self.get_path(paths)
         if not path:
             return


### PR DESCRIPTION
Adds support for defining and opening multiple terminal types. If a terminal parameter isn't passed into the command, it will look for the default `'terminal'`.

Resolves #16 and resolves #197.

#### Examples
Optional terminal definition (in `Terminal.sublime-settings` or OS specific settings):

```json
"git-bash": "C:\\Program Files\\Git\\git-bash.exe",
```

Additional Terminal: Open command (in `Default.sublime-commands`):
```json
{
    "caption":"Terminal: Open Git Bash",
    "command":"open_terminal",
    "args": {
        "terminal": "git-bash",
        "parameters": []
    }
}
```