### PR TITLE
Defaults to home folder if path can't be found

### DIFF
--- a/Terminal.py
+++ b/Terminal.py
@@ -125,16 +125,24 @@ class TerminalCommand():
             return paths[0]
         # DEV: On ST3, there is always an active view.
         #   Be sure to check that it's a file with a path (not temporary view)
-        elif self.window.active_view() and self.window.active_view().file_name():
+        if self.window.active_view() and self.window.active_view().file_name():
             return self.window.active_view().file_name()
-        elif self.window.folders():
-            return self.window.folders()[0]
+            
         else:
-            try:
-                return os.path.expanduser("~")
-            except:
-                sublime.error_message('Terminal: No place to open terminal to')
-                return False
+            fallback_solutions = get_setting('fallback_solutions', [])
+            for solution in fallback_solutions:
+                if solution == "project":
+                    if self.window.folders():
+                        return self.window.folders()[0]
+                elif solution == "home":
+                    home_folder = get_setting("homedir", "")
+                    if home_folder is not "":
+                        return home_folder
+                    else:
+                        return os.path.expanduser("~")
+
+            sublime.error_message('Terminal: No place to open terminal to')
+            return False
 
     def run_terminal(self, dir_, terminal, parameters):
         try:

--- a/Terminal.py
+++ b/Terminal.py
@@ -130,8 +130,11 @@ class TerminalCommand():
         elif self.window.folders():
             return self.window.folders()[0]
         else:
-            sublime.error_message('Terminal: No place to open terminal to')
-            return False
+            try:
+                return os.path.expanduser("~")
+            except:
+                sublime.error_message('Terminal: No place to open terminal to')
+                return False
 
     def run_terminal(self, dir_, terminal, parameters):
         try:

--- a/Terminal.py
+++ b/Terminal.py
@@ -141,7 +141,7 @@ class TerminalCommand():
                     else:
                         return os.path.expanduser("~")
 
-            sublime.error_message('Terminal: No place to open terminal to')
+            sublime.error_message('To open a terminal, you must first have an active saved file/folder. Couldn\'t find a path.')
             return False
 
     def run_terminal(self, dir_, terminal, parameters):

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -16,7 +16,7 @@
 
 	// A setting to select what to do if no path is found to open the terminal in.
 	// From highest priority to lowerst priority, options can be:
-	// - project (For files: tries to fall back to project folder)
+	// - project (For files: tries to fall back to first project folder)
 	// - home (Can be set with homedir below: if empty, defaults to user's home directory)
 	// Note that if all options fail, it will do nothing but open a error message.
 	"fallback_solutions": ["project", "home"],

--- a/Terminal.sublime-settings
+++ b/Terminal.sublime-settings
@@ -12,5 +12,13 @@
 	// An environment variables changeset. Default environment variables used for the
 	// terminal are inherited from sublime. Use this mapping to overwrite/unset. Use
 	// null value to indicate that the environment variable should be unset.
-	"env": {}
+	"env": {},
+
+	// A setting to select what to do if no path is found to open the terminal in.
+	// From highest priority to lowerst priority, options can be:
+	// - project (For files: tries to fall back to project folder)
+	// - home (Can be set with homedir below: if empty, defaults to user's home directory)
+	// Note that if all options fail, it will do nothing but open a error message.
+	"fallback_solutions": ["project", "home"],
+	"homedir": ""
 }


### PR DESCRIPTION
Using `os.path.expanduser("~")`, a built-in python function, we can open a terminal in the user's home directory. Tries to do this before returning an error. If it can't find the path, it falls back to the old error. Should work on all platforms.

Related to issue #91 .