### PR TITLE
Add example config for Windows Terminal

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,16 @@ Here are some example setups:
 }
 ```
 
+#### [Windows Terminal](https://github.com/microsoft/terminal)
+
+```js
+{
+  "terminal": "C:/Users/yourusername/AppData/Local/Microsoft/WindowsApps/wt.exe",
+  "parameters": ["-d", "."]
+}
+```
+
+
 ## Custom Parameters
 
 With the parameters argument to the *open_terminal* and *open_terminal_project_folder* commands, it is possible to construct custom terminal environments.


### PR DESCRIPTION
Just to avoid confusion when people try to use this Windows "App" as their terminal, as it doesn't have a normal executable like other programs, but _does_ have a hidden shorthand.

More info: https://github.com/microsoft/terminal