### PR TITLE
Add example for kitty on OSX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,16 @@ Here are some example setups:
 }
 ```
 
+#### Kitty on OS X
+
+```js
+{
+  // Replace with your own path to kitty
+  "terminal": "/opt/homebrew/bin/kitty",
+  "parameters": ["-d", "%CWD%"]
+}
+```
+
 #### [Windows Terminal](https://github.com/microsoft/terminal)
 
 ```js


### PR DESCRIPTION
The example launches the terminal in file or project directory for a homebrew installation of kitty on an ARM Mac.