### PR TITLE
clean up menu items and use split view

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,13 +1,9 @@
 [
     {
-        "caption": "Preferences",
-        "mnemonic": "n",
         "id": "preferences",
         "children":
         [
             {
-                "caption": "Package Settings",
-                "mnemonic": "P",
                 "id": "package-settings",
                 "children":
                 [
@@ -16,97 +12,30 @@
                         "children":
                         [
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/Terminal/Terminal.sublime-settings"},
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/Terminal.sublime-settings"},
-                                "caption": "Settings – User"
-                            },
-                            {
-                                "caption": "Settings – More",
-                                "children":
-                                [
-                                    {
-                                        "command": "open_file",
-                                        "args": {
-                                            "file": "${packages}/User/Terminal (Windows).sublime-settings",
-                                            "platform": "Windows"
-                                        },
-                                        "caption": "OS Specific – User"
-                                    },
-                                    {
-                                        "command": "open_file",
-                                        "args": {
-                                            "file": "${packages}/User/Terminal (OSX).sublime-settings",
-                                            "platform": "OSX"
-                                        },
-                                        "caption": "OS Specific – User"
-                                    },
-                                    {
-                                        "command": "open_file",
-                                        "args": {
-                                            "file": "${packages}/User/Terminal (Linux).sublime-settings",
-                                            "platform": "Linux"
-                                        },
-                                        "caption": "OS Specific – User"
-                                    }
-                                ]
-                            },
-                            {
-                                "caption": "-"
-                            },
-                            {
-                                "command": "open_file",
+                                "caption": "Settings",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/Terminal/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
+                                    "file": "${packages}/Terminal/Terminal.sublime-settings",
+                                    "default": "// Terminal Settings - User\n{\n\t$0\n}\n",
+                                }
                             },
                             {
-                                "command": "open_file",
+                                "caption": "OS Specific Settings",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/Terminal/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – Default"
+                                    "base_file": "${packages}/Terminal/Terminal.sublime-settings",
+                                    "user_file": "${packages}/User/Terminal ($platform).sublime-settings",
+                                    "default": "// Terminal OS Specific Settings - User\n{\n\t$0\n}\n"
+                                }
                             },
                             {
-                                "command": "open_file",
+                                "caption": "Key Bindings",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/Terminal/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            { "caption": "-" }
+                                    "base_file": "${packages}/Terminal/Default ($platform).sublime-keymap",
+                                    "default": "[\n\t$0\n]\n"
+                                }
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
Modernises the main menu items so that they open in Split View, reducing the need for all those different menu entries and updating the package to standard ST behaviour from wat? 2016? 

@wbond please let's move this to the [Sublime Text Packages](https://github.com/SublimeText) org so that more active users can contribute and do something about all those open issues and pull requests. (edit: I don't want to pull this away from you, but if it's easier for you I can also simply create a fork in that org and update the package control entry)